### PR TITLE
BUILDENV: Rätt portar i openshift

### DIFF
--- a/devops/openshift/test/configmap-vars.yaml
+++ b/devops/openshift/test/configmap-vars.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 data:
+  SERVER_PORT: "8080"
+  MANAGEMENT_SERVER_PORT: "8081"
   SPRING_PROFILES_ACTIVE: "dev, fake"
   REDIS_PORT: "6379"
 kind: ConfigMap


### PR DESCRIPTION
Revertar portändring i test för openshift, glömde bort att dintyg kör med dev-profilen