### PR TITLE
INTYGFV-12993: Spring Boot Version update

### DIFF
--- a/buildSrc/src/main/kotlin/se/inera/intyg/intygsadmin/build/Config.kt
+++ b/buildSrc/src/main/kotlin/se/inera/intyg/intygsadmin/build/Config.kt
@@ -11,7 +11,7 @@ object Config {
   object Dependencies {
 
     //Project dependencies
-    const val intygPluginVersion = "3.0.9"
+    const val intygPluginVersion = "3.1.0"
 
     //External dependencies
     const val nodePluginVersion = "1.3.1"
@@ -19,8 +19,8 @@ object Config {
     const val npmVersion = "6.10.3"
 
     const val kotlinVersion = "1.3.31"
-    const val springBootVersion = "2.1.9.RELEASE"
-    const val springDependencyManagementVersion = "1.0.8.RELEASE"
+    const val springBootVersion = "2.2.5.RELEASE"
+    const val springDependencyManagementVersion = "1.0.9.RELEASE"
     const val springSecurityOauth2Version = "2.3.6.RELEASE"
 
     const val embeddedRedisVersion = "0.7.2"

--- a/web/src/main/java/se/inera/intyg/intygsadmin/web/config/SwaggerConfig.java
+++ b/web/src/main/java/se/inera/intyg/intygsadmin/web/config/SwaggerConfig.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.data.domain.Pageable;
@@ -37,11 +36,12 @@ import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Profile("dev")
-@EnableSwagger2
-@Configuration
+// Removed Swagger due to bug and incompatability with newer Boot versions
+// https://github.com/springfox/springfox/issues/2932
+//@EnableSwagger2
+//@Configuration
 public class SwaggerConfig {
 
     private final TypeResolver typeResolver;


### PR DESCRIPTION
Updated Spring boot version to 2.2.5. This is needed for OCP 3.11

Problems with Swagger compatibility with no good fix, so needed to disable swagger until swagger 3.0.0 is released. This will probably take a while.