### PR TITLE
INTYGFV-12452: Harmonization of logback file usage and structure

### DIFF
--- a/web/src/main/resources/application-dev.yml
+++ b/web/src/main/resources/application-dev.yml
@@ -12,3 +12,4 @@ spring:
   output:
     ansi:
       enabled: ALWAYS
+      

--- a/web/src/main/resources/application-dev.yml
+++ b/web/src/main/resources/application-dev.yml
@@ -9,3 +9,6 @@ spring:
   h2:
     console:
       enabled: true
+  output:
+    ansi:
+      enabled: ALWAYS

--- a/web/src/main/resources/application-dev.yml
+++ b/web/src/main/resources/application-dev.yml
@@ -12,4 +12,3 @@ spring:
   output:
     ansi:
       enabled: ALWAYS
-      


### PR DESCRIPTION
Work on this jira was aimed at harmonization of logback usage across all applications and included actions in infra, common, intygsadmin, intygstjanst, logsender, minaintyg, privatlakarportal, rehabstod, statistik and webcert. Briefly, logging functionality was collected in infra/monitoring, a logback-dev file was introduced for use in dev-environment and logback-ocp files (in web/resources as a backup and in devops/openshift/test) was set to produce logging identical to current prod-logging.  A summary of all actions can be found in PRs in common and infra. 